### PR TITLE
Connect function should preserve component types

### DIFF
--- a/react-redux.d.ts
+++ b/react-redux.d.ts
@@ -20,12 +20,18 @@ declare module ReactRedux {
 		withRef?: boolean;
 	}
 
-	export function connect<TElement extends Function>(
+	type ComponentConstructor<P> = React.ComponentClass<P> | React.StatelessComponent<P>
+
+	function wrapWithConnect<T extends ComponentConstructor<any>>(
+		component: T
+	): T
+
+	export function connect(
 		mapStateToProps?: IMapStateToProps,
 		mapDispatchToProps?: IMapDispatchToProps,
 		mergeProps?: (stateProps: Object, dispatchProps: Object, ownProps: Object) => Object,
 		options?: IConnectOptions
-	): TElement;
+	): typeof wrapWithConnect;
 }
 
 export = ReactRedux;


### PR DESCRIPTION
I kind of just went ahead and created a PR for this since we needed it for our code base.

Since `TElement` was not used in the arguments of `connect`, I did not see the usefulness of it and got rid of it. Instead, `connect` now returns the `wrapWithConnect` function that takes a React component and simply returns it unchanged (as far as types are concerned).

This change makes it necessary to specify any `react-redux` props on the component as optional, otherwise the compiler will complain that they're missing. We were already doing that, but perhaps other people structure their code differently.

More interesting things could be done by typing `ownProps` or making sure `mapStateToProps` returns a subset of the component props (this might be harder with 1.8), but I'll leave that for another PR.
