### PR TITLE
Added "Object" as argument to connect

### DIFF
--- a/react-redux.d.ts
+++ b/react-redux.d.ts
@@ -28,7 +28,7 @@ declare module ReactRedux {
 
 	export function connect(
 		mapStateToProps?: IMapStateToProps,
-		mapDispatchToProps?: IMapDispatchToProps,
+		mapDispatchToProps?: IMapDispatchToProps | Object,
 		mergeProps?: (stateProps: Object, dispatchProps: Object, ownProps: Object) => Object,
 		options?: IConnectOptions
 	): typeof wrapWithConnect;


### PR DESCRIPTION
As per react-redux docs [https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options] mapDispatchToProps can take Object as an argument. 

Updated "connect" function definition to reflect that it can accept _Object_
