### PR TITLE
Update to Typings 1.0, official redux typings and improve the definitions to infer more things.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 typings
+node_modules

--- a/react-redux.d.ts
+++ b/react-redux.d.ts
@@ -23,14 +23,14 @@ interface ComponentConnector<P> {
 
 export function connect<P>(
 	mapStateToProps?: IMapStateToProps<P, P>,
-	mapDispatchToProps?: IMapDispatchToProps<P, P>,
+	mapDispatchToProps?: IMapDispatchToProps<P, P> | {},
 	mergeProps?: (stateProps: P, dispatchProps: P, ownProps: P) => P,
 	options?: IConnectOptions
 ): ComponentConnector<P>
 
 export function connect<P, SP, DP>(
 	mapStateToProps?: IMapStateToProps<P, SP>,
-	mapDispatchToProps?: IMapDispatchToProps<P, DP>,
+	mapDispatchToProps?: IMapDispatchToProps<P, DP> | {},
 	mergeProps?: (stateProps: SP, dispatchProps: DP, ownProps: P) => P & DP & SP,
 	options?: IConnectOptions
 ): ComponentConnector<P>

--- a/react-redux.d.ts
+++ b/react-redux.d.ts
@@ -1,37 +1,37 @@
-/// <reference path="typings/main.d.ts" />
+import {Component} from 'react';
+import {Store, Dispatch} from "redux";
 
-import * as React from "react";
-import {IStore, IDispatch} from "redux";
+export class Provider extends Component<{store: Store<any>}, {}> {}
 
-declare module ReactRedux {
-	
-	export class Provider extends React.Component<{store:IStore<any>},{}>{}	
-
-	export interface IMapStateToProps {
-		(state: any, ownProps?: any): Object;
-	}
-
-	export interface IMapDispatchToProps {
-		(dispatch: IDispatch, ownProps?: any): Object;
-	}
-
-	export interface IConnectOptions {
-		pure?: boolean;
-		withRef?: boolean;
-	}
-
-	type ComponentConstructor<P> = React.ComponentClass<P> | React.StatelessComponent<P>
-
-	function wrapWithConnect<T extends ComponentConstructor<any>>(
-		component: T
-	): T
-
-	export function connect(
-		mapStateToProps?: IMapStateToProps,
-		mapDispatchToProps?: IMapDispatchToProps | Object,
-		mergeProps?: (stateProps: Object, dispatchProps: Object, ownProps: Object) => Object,
-		options?: IConnectOptions
-	): typeof wrapWithConnect;
+export interface IMapStateToProps<P, SP> {
+	(state: any, ownProps?: P): SP;
 }
 
-export = ReactRedux;
+export interface IMapDispatchToProps<P, DP> {
+	(dispatch: Dispatch<any>, ownProps?: P): DP;
+}
+
+export interface IConnectOptions {
+	pure?: boolean;
+	withRef?: boolean;
+}
+
+interface ComponentConnector<P> {
+	(component: ((props: P) => JSX.Element)): ((props: P) => JSX.Element)
+	<TFunction extends Function>(component: TFunction): TFunction
+}
+
+export function connect<P>(
+	mapStateToProps?: IMapStateToProps<P, P>,
+	mapDispatchToProps?: IMapDispatchToProps<P, P>,
+	mergeProps?: (stateProps: P, dispatchProps: P, ownProps: P) => P,
+	options?: IConnectOptions
+): ComponentConnector<P>
+
+export function connect<P, SP, DP>(
+	mapStateToProps?: IMapStateToProps<P, SP>,
+	mapDispatchToProps?: IMapDispatchToProps<P, DP>,
+	mergeProps?: (stateProps: SP, dispatchProps: DP, ownProps: P) => P & DP & SP,
+	options?: IConnectOptions
+): ComponentConnector<P>
+

--- a/test.tsx
+++ b/test.tsx
@@ -1,75 +1,116 @@
-/// <reference path="./react-redux.d.ts" />
-import {Provider, connect} from "./react-redux";
-import {createStore, IActionGeneric, combineReducers, IDispatch, bindActionCreators} from "redux";
+import {Provider, connect, IMapDispatchToProps, IMapStateToProps, IConnectOptions} from "./react-redux";
+import {createStore, Action, combineReducers, Dispatch, bindActionCreators} from "redux";
 import * as React from "react";
 
 interface IState {
 	greeting: string;
 }
 
-function changeGreeting(greeting:string):IActionGeneric<string>{
+interface IAction extends Action {
+	payload: string;
+}
+
+function changeGreeting(greeting: string): IAction {
 	return {
-		type : "CHANGE_GREETING",
-		payload : greeting
+		type: "CHANGE_GREETING",
+		payload: greeting
 	};
 }
 
-function greetingReducer(greeting: string = "world", action: IActionGeneric<string>) {
+function greetingReducer(greeting: string = "world", action: IAction) {
 	switch (action.type) {
-		case "CHANGE_GREETING": return action.payload;
+		case "CHANGE_GREETING":
+			return action.payload;
 	}
-	
+
 	return greeting;
 }
 
 const rootReducer = combineReducers<IState>({
-	greeting : greetingReducer
+	greeting: greetingReducer
 });
 
-const store = createStore(rootReducer)
+const store = createStore(rootReducer);
 
-interface IGreeterProps{
-	subject? : string;
-	onGreet? : (newGreet:string) => any
+interface IGreeterProps {
+	subject?: string;
+	onGreet?: (newGreet: string) => any
 };
 
 
-function mapStateToProps(state:IState):IGreeterProps{
+function mapStateToProps(state: IState): IGreeterProps {
 	return {
-		subject : state.greeting
+		subject: state.greeting
 	};
 }
 
-function mapDispatchToProps(dispatch:IDispatch):IGreeterProps{
+function mapDispatchToProps(dispatch: Dispatch<any>): IGreeterProps {
 	return {
-	  onGreet : bindActionCreators(changeGreeting,dispatch)
+		onGreet: bindActionCreators(changeGreeting, dispatch)
 	};
 }
 
 @connect(mapStateToProps, mapDispatchToProps)
-class Greeter extends React.Component<IGreeterProps, {}>{
-	render(){
+class Greeter extends React.Component<IGreeterProps & {mandatory: string}, {}> {
+	render() {
 		return (
 			<div>
 				<h1>Hello {this.props.subject}</h1>
 				<input type="text" ref="input"/>
-				<button onClick={() => this.greet()}></button>
-			</div>	
+				<button onClick={() => this.greet() }></button>
+			</div>
 		);
 	}
-	
-	greet(){
+
+	greet() {
 		let htmlInput = this.refs["input"] as HTMLInputElement;
 		this.props.onGreet(htmlInput.value);
 		htmlInput.value = "";
 	}
 }
 
-//Just trying out the old style and the decorator
+<Greeter mandatory="mandatory" />
+
+// Just trying out the old style and the decorator
 const ConnectedGreeter = connect(mapStateToProps, mapDispatchToProps)(Greeter)
+
+// Trying out with function components
+function FunctionGreeter(props: IGreeterProps) {
+	return (
+		<div>
+			<h1>Hello {props.subject}</h1>
+			<input type="text" ref="input"/>
+		</div>
+	);
+}
+const ConnectedFunctionGreeter = connect(mapStateToProps, mapDispatchToProps)(FunctionGreeter);
 
 const App = () => (
 	<Provider store={store}>
-		<ConnectedGreeter></ConnectedGreeter>
-	</Provider>	
+		<ConnectedGreeter mandatory="mandatory" />
+		<ConnectedFunctionGreeter />
+	</Provider>
 );
+
+function connected<P, SP, DP>(
+    {defaultProps, mapStateToProps, mapDispatchToProps, mergeProps, options}: {
+        defaultProps: P,
+        mapStateToProps?: IMapStateToProps<P, SP>,
+        mapDispatchToProps?: IMapDispatchToProps<P, DP>,
+        mergeProps?: (stateProps: SP, dispatchProps: DP, ownProps: P) => P & DP & SP,
+        options?: IConnectOptions
+    },
+    component: (props: P & SP & DP) => JSX.Element
+) {
+    component['defaultProps'] = defaultProps;
+    return connect<P, SP, DP>(mapStateToProps, mapDispatchToProps, mergeProps, options)(component);
+}
+
+const Test = connected({
+    defaultProps: {} as {yolo: number},
+    mapStateToProps: ({lol}: {lol: string}) => ({lol})
+}, function Component({lol, yolo}) {
+    return <div>{lol}{yolo}</div>;
+});
+
+<Test yolo={3} />;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,10 @@
 {
 	"compilerOptions": {
 		"target": "es6",
-		"noEmit": true,		
+		"noEmit": true,
 		"suppressExcessPropertyErrors": true,
 		"experimentalDecorators": true,
 		"module": "commonjs",
 		"jsx":"react"
-	},
-	"exclude": [
-		"typings"
-	]
+	}
 }

--- a/typings.json
+++ b/typings.json
@@ -1,12 +1,12 @@
 {
 	"name": "react-redux",
 	"ambient": false,
-	"main":"react-redux.d.ts",
+	"main": "react-redux.d.ts",
 	"dependencies": {
-		"redux": "github:andrew-w-ross/typings-redux"
+		"redux": "npm:redux"
 	},
 	"devDependencies": {},
-	"ambientDependencies": {
-		"react": "github:DefinitelyTyped/DefinitelyTyped/react/react.d.ts#83b88a031cc8f2006fd361bf0a0b548c3bcc8259"
+	"globalDependencies": {
+		"react": "registry:dt/react#0.14.0+20160602151522"
 	}
 }


### PR DESCRIPTION
That would solve #5. For the install to work, you must have `redux` installed in your `node_modules`. To try out the tests of this repo, you would have to also install it.

I tried to type the different objects more precisely, which changes a little the way it works when connecting functions. You might have to add (depending on how you typed the connect parameters) a type annotation to connect, but in exchange you get the possibility to write a tiny wrapper around connect that infers everything. It's all demoed in the test file, so please take a look at it and tell me what you think.

Thanks.
